### PR TITLE
Headless Vulkan fixed and updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,10 +211,7 @@ jobs:
       fail-fast: true
       matrix:
         include: [
-          { platform: arm    },
           { platform: arm64  },
-          { platform: x86    },
-          { platform: x86_64 },
         ]
     name: android-${{ matrix.platform }}
     runs-on: ubuntu-22.04

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2001,6 +2001,12 @@ namespace bgfx
 			return false;
 		}
 
+		if (m_renderCtx->getRendererType() == RendererType::Vulkan && _init.platformData.nwh == nullptr) {
+			// create a default backbuffer if in Vulkan headless mode
+			createBackBuffer(_init.resolution);
+			frame();
+		}
+
 		for (uint32_t ii = 0; ii < BX_COUNTOF(s_emulatedFormats); ++ii)
 		{
 			const uint32_t fmt = s_emulatedFormats[ii];
@@ -3264,7 +3270,10 @@ namespace bgfx
 						Attachment attachment[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
 						_cmdbuf.read(attachment, sizeof(Attachment) * num);
 
-						m_renderCtx->createFrameBuffer(handle, num, attachment);
+						if (isValid(handle))
+							m_renderCtx->createFrameBuffer(handle, num, attachment);
+						else
+							m_renderCtx->createBackBuffer(num, attachment);
 					}
 				}
 				break;

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1958,6 +1958,14 @@ namespace bgfx { namespace d3d11
 			}
 		}
 
+		// creates a backbuffer in headless mode.
+		void createBackBuffer(uint8_t _num, const Attachment* _attachment) override
+		{
+			BX_UNUSED(_num);
+			BX_UNUSED(_attachment);
+			BX_WARN(true, "createBackBuffer is not supported in DX11");
+		}
+
 		void createUniform(UniformHandle _handle, UniformType::Enum _type, uint16_t _num, const char* _name) override
 		{
 			if (NULL != m_uniforms[_handle.idx])

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -1863,6 +1863,14 @@ namespace bgfx { namespace d3d12
 			}
 		}
 
+		// creates a backbuffer in headless mode.
+		void createBackBuffer(uint8_t _num, const Attachment* _attachment) override
+		{
+			BX_UNUSED(_num);
+			BX_UNUSED(_attachment);
+			BX_WARN(true, "createBackBuffer is not supported in DX12");
+		}
+
 		void createUniform(UniformHandle _handle, UniformType::Enum _type, uint16_t _num, const char* _name) override
 		{
 			if (NULL != m_uniforms[_handle.idx])

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -1221,6 +1221,14 @@ namespace bgfx { namespace d3d9
 			}
 		}
 
+		// creates a backbuffer in headless mode.
+		void createBackBuffer(uint8_t _num, const Attachment* _attachment) override
+		{
+			BX_UNUSED(_num);
+			BX_UNUSED(_attachment);
+			BX_WARN(true, "createBackBuffer is not supported in DX9");
+		}
+
 		void createUniform(UniformHandle _handle, UniformType::Enum _type, uint16_t _num, const char* _name) override
 		{
 			if (NULL != m_uniforms[_handle.idx])

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -3526,6 +3526,14 @@ namespace bgfx { namespace gl
 			}
 		}
 
+		// creates a backbuffer in headless mode.
+		void createBackBuffer(uint8_t _num, const Attachment* _attachment) override
+		{
+			BX_UNUSED(_num);
+			BX_UNUSED(_attachment);
+			BX_WARN(true, "createBackBuffer is not supported in OpenGL / GLES");
+		}
+
 		void createUniform(UniformHandle _handle, UniformType::Enum _type, uint16_t _num, const char* _name) override
 		{
 			if (NULL != m_uniforms[_handle.idx])

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -1141,6 +1141,14 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 			}
 		}
 
+		// creates a backbuffer in headless mode.
+		void createBackBuffer(uint8_t _num, const Attachment* _attachment) override
+		{
+			BX_UNUSED(_num);
+			BX_UNUSED(_attachment);
+			BX_WARN(true, "createBackBuffer is not supported in Metal");
+		}
+
 		void createUniform(UniformHandle _handle, UniformType::Enum _type, uint16_t _num, const char* _name) override
 		{
 			if (NULL != m_uniforms[_handle.idx])

--- a/src/renderer_noop.cpp
+++ b/src/renderer_noop.cpp
@@ -207,6 +207,11 @@ namespace bgfx { namespace noop
 		{
 		}
 
+		// creates a backbuffer in headless mode.
+		void createBackBuffer(uint8_t /*_num*/, const Attachment* /*_attachment*/) override
+		{
+		}
+
 		void createUniform(UniformHandle /*_handle*/, UniformType::Enum /*_type*/, uint16_t /*_num*/, const char* /*_name*/) override
 		{
 		}

--- a/src/renderer_webgpu.cpp
+++ b/src/renderer_webgpu.cpp
@@ -1019,6 +1019,14 @@ namespace bgfx { namespace webgpu
 			}
 		}
 
+		// creates a backbuffer in headless mode.
+		void createBackBuffer(uint8_t _num, const Attachment* _attachment) override
+		{
+			BX_UNUSED(_num);
+			BX_UNUSED(_attachment);
+			BX_WARN(true, "createBackBuffer is not supported in WebGPU");
+		}
+
 		void createUniform(UniformHandle _handle, UniformType::Enum _type, uint16_t _num, const char* _name) override
 		{
 			if (NULL != m_uniforms[_handle.idx])


### PR DESCRIPTION
- initialise m_backBuffer with an offscreen frame buffer w/ custom attachments in headless mode so we can bind it and read from it
- added support for screenshots and movie capture in headless mode
- fixes asserts in debug mode when trying to blit textures or dispatch compute pipelines. Both operations for which it tries to bind the backbuffer when there's really no need to. 
- To minimise hacks and integrate it better with the bgfx workflow it required adding a new createBackBuffer method to RendererContextI. Note that this is only implemented in renderer_vk.cpp. All other backends contain a stub 
