### PR TITLE
Fix for assertion in windowed mode during blitSetup

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -2856,7 +2856,8 @@ VK_IMPORT_DEVICE
 		{
 			BX_ASSERT(false
 				  ||  isValid(_fbh)
-				  ||  m_backBuffer.isRenderable()
+				  ||  NULL != m_backBuffer.m_nwh
+					||  VK_NULL_HANDLE != m_backBuffer.m_framebuffer   // this is the headless backbuffer
 				, "Trying to bind an invalid framebuffer."
 				);
 


### PR DESCRIPTION
Changed the "backbuffer is valid" check from `isRenderable()` - which implies the swapchain has not yet been flushed to the display - to: 

```
NULL != m_backBuffer.m_nwh // in windowed mode, as it is in the main repo 
||  VK_NULL_HANDLE != m_backBuffer.m_framebuffer  // to check if the headless backbuffer is valid.
```
