### PR TITLE
Dynamic scratch buffer memory management

### DIFF
--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -378,6 +378,12 @@ VK_DESTROY_FUNC(DescriptorSet);
 		uint8_t* m_data;
 		uint32_t m_size;
 		uint32_t m_pos;
+
+	private:
+		uint32_t m_entrySize;
+		uint32_t m_entriesCount;
+
+		void grow();
 	};
 
 	struct BufferVK


### PR DESCRIPTION
Option to grow the scratch buffer when it runs out of memory instead of asserting. Also, fixed the "out of memory" check.