### PR TITLE
Fixed crash during video capture

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -2729,7 +2729,7 @@ VK_IMPORT_DEVICE
 			if (m_resolution.reset & BGFX_RESET_CAPTURE)
 			{
 				bimg::TextureFormat::Enum colourFormat;
-				if (isSwapChainReadable(m_backBuffer.m_swapChain))
+				if (NULL != m_backBuffer.m_nwh)
 				{
 					colourFormat = bimg::TextureFormat::Enum(m_backBuffer.m_swapChain.m_colorFormat);
 				}
@@ -4070,8 +4070,8 @@ VK_IMPORT_DEVICE
 				const VkImage image = swapChain.m_backBufferColorImage[swapChain.m_backBufferColorIdx];
 				const VkImageLayout layout = swapChain.m_backBufferColorImageLayout[swapChain.m_backBufferColorIdx];
 
-				const uint32_t width  = swapChain.m_sci.imageExtent.width;
-				const uint32_t height = swapChain.m_sci.imageExtent.height;
+				const uint32_t width  = m_backBuffer.m_width;
+				const uint32_t height = m_backBuffer.m_height;
 
 				ReadbackVK readback;
 				readback.create(image, width, height, swapChain.m_colorFormat);

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -763,6 +763,9 @@ VK_DESTROY_FUNC(DescriptorSet);
 			, m_needPresent(false)
 			, m_framebuffer(VK_NULL_HANDLE)
 		{
+			for (int i = 0; i < BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS; ++i) {
+				m_texture[i] = { kInvalidHandle };
+			}
 		}
 
 		void create(uint8_t _num, const Attachment* _attachment);


### PR DESCRIPTION
- make sure all backbuffer attachments are initialised to invalid handles
- fixed "not headless" check
- partial fix for incorrect video stride: read the width and height setting from m_backbuffer instead of the swapchain image extent. These should always match, except in the case where the requested video size has been capped by the limits in surface capabilities. In that case, we at least get "correct" video with black borders (or a cropped image) instead of crashing or getting noise out.